### PR TITLE
close #38 メンバーリスト及び論文リストの更新

### DIFF
--- a/html/member.php
+++ b/html/member.php
@@ -59,6 +59,10 @@
         <?php $members = $bachelors; ?>
         <?php include (dirname(__FILE__).'/parts/member_list/hinagata.php'); ?>
 
+        <!-- 職名等の英語表記に関する参考文献： https://www.t.kyoto-u.ac.jp/ja/about/name/8dyy8q -->
+        <h2 class="f-h2">技術補佐員 <small>Assistant Technical Staff</small></h2>
+        <?php $members = $assistant_technical_staff; ?>
+        <?php include (dirname(__FILE__).'/parts/member_list/hinagata.php'); ?>
     </div>
 
     <!-- フッター -->

--- a/html/parts/member_list/member_list.php
+++ b/html/parts/member_list/member_list.php
@@ -2,26 +2,30 @@
 
 $doctors = array(
     //ここにメンバーを追加
-    'チャンドラ'=>array('D3', 'MOHAMAD CHANDRA SAPTRA', ''),
-    'バユ'=>array('D2', 'BAYU PRIYAMBADHA', '')
+    'バユ'=>array('D3', 'BAYU PRIYAMBADHA', ''),
 );
 
 $masters = array(
     //ここにメンバーを追加
-    '有馬 薫'=>array('M2', 'Kaoru ARIMA', ''),
-    '上田 高寛'=>array('M1', 'Takahiro UEDA', 'https://takahiro55555.github.io/'),
-    '菅 健将'=>array('M1', 'Kensuke SUGA', ''),
-    '武藤 崇史'=>array('M1', 'Takafumi MUTO', ''),
+    '上田 高寛'=>array('M2', 'Takahiro UEDA', ''),
+    '菅 健将'=>array('M2', 'Kensuke SUGA', ''),
+    '武藤 崇史'=>array('M2', 'Takafumi MUTO', ''),
+    '児玉 純輝'=>array('M1', 'Junki KODAMA', ''),
+    '宮下 丈明'=>array('M1', 'Takeaki MIYASHITA', ''),
 );
 
 $bachelors = array(
     //ここにメンバーを追加
-    '内山 大和'=>array('B4', 'Yamato UCHIYAMA', ''),
-    '児玉 純輝'=>array('B4', 'Junki KODAMA', ''),
-    '田中 佑和'=>array('B4', 'Yuto TANAKA', ''),
-    '萩山 恒威'=>array('B4', 'Hisataka HAGIYAMA', ''),
-    '樋口 裕翔'=>array('B4', 'Hiroto HIGUCHI', ''),
-    '宮下 丈明'=>array('B4', 'Takeaki MIYASHITA', ''),
+    '翁長 春樹'=>array('B4', 'Haruki ONAGA', ''),
+    '柿木 幹太'=>array('B4', 'Kanta KAKINOKI', ''),
+    '榊原 一真'=>array('B4', 'Kazuma SAKAKIBARA', ''),
+    '坂本 和哉'=>array('B4', 'Kazuya SAKAMOTO', ''),
+    '正木 涼太'=>array('B4', 'Ryota MASAKI', ''),
+);
+
+$assistant_technical_staff = array(
+    //ここにメンバーを追加
+    'チャンドラ'=>array('', 'MOHAMAD CHANDRA SAPTRA', ''),
 );
 
 ?>

--- a/html/parts/papers_list/papers2022.php
+++ b/html/parts/papers_list/papers2022.php
@@ -1,0 +1,22 @@
+<?php
+
+$doctors = array(
+    //ここにメンバーを追加
+    'Mochamad Chandra Saputra'=>array('A Study on Quality Attributes of Test Suite Quality Measurement in White-Box Testing'),
+);
+
+$masters = array(
+    //ここにメンバーを追加
+    '有馬 薫'=>array('UMLとJavaソースコード間のトレーサビリティをリアルタイムに維持するツールRETUSSにおける変換機能の拡張による適用範囲の拡大'),
+);
+
+$bachelors = array(
+    //ここにメンバーを追加
+    '内山 大和'=>array('ソースコードの品質向上を目的としたコメント解析ツールSCCAの検出切替設定項目の追加とコメント記述支援機能の追加'),
+    '児玉 純輝'=>array('コードレビュー時の視線計測結果分析ツールGAFFAの試作'),
+    '萩山 恒威'=>array('深層学習による文書画像の領域分割およびラベル生成ツールASLAの試作'),
+    '樋口 裕翔'=>array('視覚障害者を対象とした外出支援iOSアプリ「LEAD WAY」の開発'),
+    '宮下 丈明'=>array('障害児童福祉施設向け業務支援Webアプリ「リンク」の開発'),
+);
+
+?>

--- a/html/parts/papers_list/year_list.php
+++ b/html/parts/papers_list/year_list.php
@@ -1,7 +1,7 @@
 <?php
 
     $first_year = 2013;
-    $last_year = 2021;
+    $last_year = 2022;
 
     if (isset($_GET["year"]) && (int)$_GET["year"] >= $first_year && (int)$_GET["year"] <= $last_year) {
         $year = (int)$_GET["year"];


### PR DESCRIPTION
## 変更点
- 2021に発表した卒論・修論・博論リストを作成
- メンバーリストを2022年度のものに更新
- メンバーリストに「技術補佐員」の欄を追加